### PR TITLE
removing orphans

### DIFF
--- a/public_html/css/main.css
+++ b/public_html/css/main.css
@@ -431,7 +431,7 @@ nav h3 {
 		font-size: 2em;
 	}
 	.keynote h2 {
-		font-size: 2em;
+		font-size: 1.9em;
 	}
 	/*Section Content CSS*/
 	


### PR DESCRIPTION
Lowered the keynote text size on desktop 1em to avoid the orphaned word on the marina keynote image. Was driving me nuts
