### PR TITLE
blue dragon tex tbox

### DIFF
--- a/public_html/css/main.css
+++ b/public_html/css/main.css
@@ -317,21 +317,16 @@ nav h3 {
 		margin-bottom:20px;
 		}
 		
+#dragonText{
+	padding:10px;
+	margin:10px 0 20px 0;
+	}
+		
 #usDroughtGif{
 	margin-top:20px;
 	}
 	
-#texas-thumbnail{
-	margin:100px auto 10px auto;
-	background:rgba(0,51,102,.2);
-	padding:10px;
-	border-radius:5px;
-	width:100%;
-	}
-	
-#texas-thumbnail img{
-	width:100%;
-	}
+
 	
 .explore-more{
 	margin-top:20px;
@@ -570,12 +565,8 @@ nav h3 {
 	/*Blue Dragon Section CSS*/
 	
 	#blueDragon{
-		width:900px;
+		width:700px;
 		margin:20px auto;
-		}
-		
-	#texas-thumbnail{
-		width:50%;
 		}
 		
 	#natural-flow-graph{

--- a/public_html/sections/blue-dragon/blue-dragon.html
+++ b/public_html/sections/blue-dragon/blue-dragon.html
@@ -4,8 +4,11 @@
 		
 		<object id="bluedragon-object" data="img/bluedragon-animate.svg" type="image/svg+xml" ></object>
 	</div>
+	
+	
 
 	<div class="sectionContent">
+	<div id="dragonText">Rawr, here I am!! Put text about me here</div>
 		<div class="graphCaption">
 			<p class="explore-more"><a href="http://txpub.usgs.gov/DSS/StoryMaps/BlueDragon/" target="_blank"><img class="leaving" src="{{baseUrl}}/img/leavingapp-icon.png" alt="leaving application icon"/>Click here</a> to explore the lower Colorado control structures and major diversions.</p>
 		</div>


### PR DESCRIPTION
@jiwalker-usgs I tried to get a text box on the right hand side of the dragon on bigger screens, the problem was depending on the size the text either looked to far away, or on smaller sizes it ended up overlapping the dragon, either do to the dragon zooming in function or just overlapping it in general.

I chose a underneath approach instead, its less code and with the dragon desized a little bit I think it works.  If you want it on the right hand side for sure though, I'm sure media queries will have a solution until mobile size comes about.  

Also if the dragon being smaller on desktop some how screws up what you were doing with the map I can easily change that back as well.
