### PR TITLE
switched paragraph text

### DIFF
--- a/public_html/sections/before-after/before-after.html
+++ b/public_html/sections/before-after/before-after.html
@@ -75,7 +75,7 @@
   
   	<p><strong>In July 2015, Lake Mead water surface elevation dropped to 1075 feet, a decrease of 137 feet from its elevation of 1212 feet during the non-drought conditions of 1999</strong>. The lower left and center photos show the upstream face of Hoover Dam and Lake Mead in 2003, with the lake at elevation at 1196 feet (left) and the upstream face of Hoover Dam and Lake Mead in June 2015, with the lake at elevation 1078 feet (center).
 	</p>
-	<p>The photos on the bottom show the weir for the Dam’s Nevada <a href="https://en.wikipedia.org/wiki/Hoover_Dam#Spillways" target="_blank">spillway</a>. There are two spillways at Hoover Dam, one on the Arizona side and one on the Nevada side. The spillways are used to prevent the Dam from overtopping during high water periods. When water reaches a certain elevation, it flows over the weirs and into the spillways, bypassing the dam via a series of tunnels and re-entering the river channel below the dam. The left bottom photo was taken in November 2003, with the lake elevation 1196  feet; the right bottom photo was taken in May 2015, with the lake at elevation 1078 feet. </p>
+	<p>The photos on the bottom show the weir for the Dam’s Nevada <a href="http://www.usbr.gov/lc/hooverdam/History/essays/spillways.html" target="_blank">spillway</a>. There are two spillways at Hoover Dam, one on the Arizona side and one on the Nevada side. The spillways are used to prevent the Dam from overtopping during high water periods. When water reaches the top of the spillway drum gates, it flows into the spillways, bypassing the dam via a series of tunnels and re-entering the river channel below the dam.</p>
 
 
 <!--Docks-->


### PR DESCRIPTION
The photos on the bottom show the weir for the Dam’s Nevada spillway. There are two spillways at Hoover Dam, one on the Arizona side and one on the Nevada side. The spillways are used to prevent the Dam from overtopping during high water periods. When water reaches the top of the spillway drum gates, it flows into the spillways, bypassing the dam via a series of tunnels and re-entering the river channel below the dam.

Is the new text for one of the before after slider
