### PR TITLE
text moving from one section to another

### DIFF
--- a/public_html/sections/dygraphsection/dygraphsection.html
+++ b/public_html/sections/dygraphsection/dygraphsection.html
@@ -1,8 +1,6 @@
 <div class="widget">
 	<div class="sectionContent">
 		<p> Since 2000, the Upper Colorado River Basin has experienced the 15 driest years in over 100 years of historical recorded flows and one of the most severe droughts in the last 1200 years. </p>
-        <p>90% of the total basin water supply for both the Upper and Lower Basins comes from the Upper Basin, so a drought in the Upper Basin has a significant impact on the Lower Basin. Of water supply from the Upper Basin, about 50% of streamflow comes from groundwater.</p>
-			
             
         <button class="supportinginfo" id="section6Button">Supporting Info</button>
         

--- a/public_html/sections/waterSupplyVariableContent/waterSupplyVariableContent.html
+++ b/public_html/sections/waterSupplyVariableContent/waterSupplyVariableContent.html
@@ -1,6 +1,8 @@
 <div class="widget">
     <div class="sectionContent">
 	
+		<p>90% of the total basin water supply for both the Upper and Lower Basins comes from the Upper Basin, so a drought in the Upper Basin has a significant impact on the Lower Basin. Of water supply from the Upper Basin, about 50% of streamflow comes from groundwater.</p>
+	
 		<object id="droughtMovingAvg-object" data="img/droughtMovingAverage.svg" type="image/svg+xml">
 		</object>
 		


### PR DESCRIPTION
90% of the total basin water supply for both the Upper and Lower Basins comes from the Upper Basin, so a drought in the Upper Basin has a significant impact on the Lower Basin. Of water supply from the Upper Basin, about 50% of streamflow comes from groundwater.

Moved from dygraph section to the water supply variable section
