### PR TITLE
Finishing off changes.

### DIFF
--- a/public_html/img/droughtMovingAverage.svg
+++ b/public_html/img/droughtMovingAverage.svg
@@ -120,9 +120,11 @@
   <g>
     <g transform="translate(65 10)">
       <rect fill="#A3FF75" height="250" width="66.6666666667" x="25.0" y="0"/>
-      <text fill="black" font-size="6" x="27.0" y="23">Pre-Compact Period</text>
+      <text fill="black" font-size="8" x="27.0" y="10">Pre-Compact</text>
+      <text fill="black" font-size="8" x="27.0" y="20">Period</text>
       <rect fill="#CCCCB2" height="250" width="66.6666666667" x="416.666666667" y="0"/>
-      <text fill="black" font-size="6" x="418.666666667" y="23">Current Drought Period</text>
+      <text fill="black" font-size="8" x="418.666666667" y="10">Current Drought</text>
+      <text fill="black" font-size="8" x="418.666666667" y="20">Period</text>
       <g fill="none" stroke="#9999FF" stroke-width="2">
         <polyline id="pline2" points="25.0,78.453 29.1666666667,51.3426375 33.3333333333,166.112225 37.5,35.02335 41.6666666667,130.0419375 45.8333333333,116.874725 50.0,79.7074375 54.1666666667,130.79525 58.3333333333,45.5648375 62.5,142.2091 66.6666666667,60.7139375 70.8333333333,25.71495 75.0,114.1757875 79.1666666667,154.3579125 83.3333333333,33.9046125 87.5,30.9152125 91.6666666667,81.91005 95.8333333333,74.6994125 100.0,139.0275375 104.166666667,132.1162125 108.333333333,122.328375 112.5,68.25985 116.666666667,100.5708125 120.833333333,39.6302 125.0,129.737 129.166666667,206.5733375 133.333333333,94.722675 137.5,160.206225 141.666666667,235.272625 145.833333333,154.6206375 150.0,129.3891125 154.166666667,133.6743 158.333333333,85.6460125 162.5,172.949225 166.666666667,188.3543 170.833333333,61.0415375 175.0,97.1858 179.166666667,140.8574875 183.333333333,120.382225 187.5,135.7434 191.666666667,173.8068125 195.833333333,107.0064375 200.0,123.2588375 204.166666667,100.8302375 208.333333333,148.2448 212.5,156.176325 216.666666667,52.432225 220.833333333,172.9322625 225.0,206.298725 229.166666667,194.82615 233.333333333,169.664075 237.5,43.7379625 241.666666667,114.2186125 245.833333333,192.5228875 250.0,168.448 254.166666667,187.3717625 258.333333333,95.2798875 262.5,204.1364875 266.666666667,182.786625 270.833333333,68.4663125 275.0,184.6831125 279.166666667,167.8722125 283.333333333,142.1423625 287.5,124.9308625 291.666666667,125.643775 295.833333333,125.1845375 300.0,148.54515 304.166666667,85.5288875 308.333333333,150.989275 312.5,105.8159875 316.666666667,174.46945 320.833333333,245.491275 325.0,123.2853 329.166666667,94.5754 333.333333333,94.510225 337.5,201.2817125 341.666666667,96.1492875 345.833333333,17.681075 350.0,8.19945 354.166666667,50.0764875 358.333333333,25.6774625 362.5,121.5663875 366.666666667,173.2143375 370.833333333,194.5758875 375.0,195.99795 379.166666667,158.789475 383.333333333,176.043525 387.5,76.477075 391.666666667,180.7610375 395.833333333,62.863275 400.0,135.0598 404.166666667,41.738975 408.333333333,103.8165125 412.5,114.627625 416.666666667,181.13785 420.833333333,178.54855 425.0,237.1403125 429.166666667,181.198025 433.333333333,188.732625 437.5,99.0033875 441.666666667,143.505925 445.833333333,170.2082125 450.0,111.4314 454.166666667,136.2774625 458.333333333,153.53235 462.5,60.7758875 466.666666667,218.1644625 470.833333333,189.3625 475.0,132.3375 479.166666667,134.15 "/>
       </g>
@@ -130,445 +132,445 @@
         <polyline id="pline1" points="62.5,97.61245 66.6666666667,95.83854375 70.8333333333,93.275775 75.0,88.08213125 79.1666666667,100.0155875 83.3333333333,90.401855 87.5,81.80590375 91.6666666667,82.026165 95.8333333333,76.41658125 100.0,85.76285125 104.166666667,84.7535625 108.333333333,90.91500625 112.5,95.16949625 116.666666667,93.80899875 120.833333333,82.3362275 125.0,91.91946625 129.166666667,109.48527875 133.333333333,110.76654125 137.5,119.3172225 141.666666667,128.94173125 145.833333333,131.19217375 150.0,131.8982475 154.166666667,138.4396925 158.333333333,136.9472125 162.5,150.279115 166.666666667,156.140845 170.833333333,141.587665 175.0,141.8339775 179.166666667,139.89910375 183.333333333,128.41006375 187.5,126.52234 191.666666667,130.96411 195.833333333,128.29732375 200.0,132.05860625 204.166666667,124.8467075 208.333333333,120.8357575 212.5,130.34923625 216.666666667,125.87387875 220.833333333,129.08135625 225.0,137.67300625 229.166666667,143.58128125 233.333333333,143.1670075 237.5,136.84016 241.666666667,135.9361375 245.833333333,145.1054025 250.0,147.1257225 254.166666667,150.24526625 258.333333333,154.5300325 262.5,157.650455 266.666666667,155.299245 270.833333333,142.66326125 275.0,144.165165 279.166666667,156.57859 283.333333333,159.370965 287.5,152.6117625 291.666666667,148.33134 295.833333333,142.1126175 300.0,147.43914375 304.166666667,135.57838375 308.333333333,132.39864875 312.5,136.13361625 316.666666667,135.11225 320.833333333,142.87415625 325.0,140.98845 329.166666667,137.95290375 333.333333333,134.83954875 337.5,142.44926625 341.666666667,137.20968 345.833333333,130.42489875 350.0,116.14591625 354.166666667,110.57196625 358.333333333,95.6927675 362.5,83.30027875 366.666666667,88.2931825 370.833333333,98.29323125 375.0,108.44200375 379.166666667,104.19278 383.333333333,112.18220375 387.5,118.06180375 391.666666667,135.3179625 395.833333333,136.59664125 400.0,147.534875 404.166666667,139.55213375 408.333333333,132.61235125 412.5,124.617525 416.666666667,123.131515 420.833333333,125.1074225 425.0,131.21710125 429.166666667,141.68919625 433.333333333,142.486355 437.5,146.10036625 441.666666667,146.94497875 445.833333333,159.7919025 450.0,160.55339125 454.166666667,162.718375 458.333333333,159.957825 462.5,148.18055875 466.666666667,146.28297375 470.833333333,147.09942125 475.0,141.45990875 479.166666667,144.97457 "/>
       </g>
       <rect class="linebox" fill="black" height="250" id="box0" opacity="0" width="4.16666666667" x="25.0" y="0"/>
-      <text class="num0" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume:  maf</text>
-      <text class="num0" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1906</text>
-      <text class="num0" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 18.72 maf</text>
+      <text class="num0" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average:  maf</text>
+      <text class="num0" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1906</text>
+      <text class="num0" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 18.72 maf</text>
       <rect class="linebox" fill="black" height="250" id="box1" opacity="0" width="4.16666666667" x="29.1666666667" y="0"/>
-      <text class="num1" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume:  maf</text>
-      <text class="num1" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1907</text>
-      <text class="num1" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 20.89 maf</text>
+      <text class="num1" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average:  maf</text>
+      <text class="num1" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1907</text>
+      <text class="num1" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 20.89 maf</text>
       <rect class="linebox" fill="black" height="250" id="box2" opacity="0" width="4.16666666667" x="33.3333333333" y="0"/>
-      <text class="num2" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume:  maf</text>
-      <text class="num2" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1908</text>
-      <text class="num2" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 11.71 maf</text>
+      <text class="num2" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average:  maf</text>
+      <text class="num2" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1908</text>
+      <text class="num2" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 11.71 maf</text>
       <rect class="linebox" fill="black" height="250" id="box3" opacity="0" width="4.16666666667" x="37.5" y="0"/>
-      <text class="num3" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume:  maf</text>
-      <text class="num3" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1909</text>
-      <text class="num3" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 22.2 maf</text>
+      <text class="num3" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average:  maf</text>
+      <text class="num3" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1909</text>
+      <text class="num3" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 22.2 maf</text>
       <rect class="linebox" fill="black" height="250" id="box4" opacity="0" width="4.16666666667" x="41.6666666667" y="0"/>
-      <text class="num4" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume:  maf</text>
-      <text class="num4" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1910</text>
-      <text class="num4" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 14.6 maf</text>
+      <text class="num4" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average:  maf</text>
+      <text class="num4" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1910</text>
+      <text class="num4" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 14.6 maf</text>
       <rect class="linebox" fill="black" height="250" id="box5" opacity="0" width="4.16666666667" x="45.8333333333" y="0"/>
-      <text class="num5" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume:  maf</text>
-      <text class="num5" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1911</text>
-      <text class="num5" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 15.65 maf</text>
+      <text class="num5" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average:  maf</text>
+      <text class="num5" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1911</text>
+      <text class="num5" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 15.65 maf</text>
       <rect class="linebox" fill="black" height="250" id="box6" opacity="0" width="4.16666666667" x="50.0" y="0"/>
-      <text class="num6" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume:  maf</text>
-      <text class="num6" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1912</text>
-      <text class="num6" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 18.62 maf</text>
+      <text class="num6" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average:  maf</text>
+      <text class="num6" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1912</text>
+      <text class="num6" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 18.62 maf</text>
       <rect class="linebox" fill="black" height="250" id="box7" opacity="0" width="4.16666666667" x="54.1666666667" y="0"/>
-      <text class="num7" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume:  maf</text>
-      <text class="num7" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1913</text>
-      <text class="num7" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 14.54 maf</text>
+      <text class="num7" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average:  maf</text>
+      <text class="num7" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1913</text>
+      <text class="num7" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 14.54 maf</text>
       <rect class="linebox" fill="black" height="250" id="box8" opacity="0" width="4.16666666667" x="58.3333333333" y="0"/>
-      <text class="num8" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume:  maf</text>
-      <text class="num8" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1914</text>
-      <text class="num8" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 21.35 maf</text>
+      <text class="num8" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average:  maf</text>
+      <text class="num8" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1914</text>
+      <text class="num8" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 21.35 maf</text>
       <rect class="linebox" fill="black" height="250" id="box9" opacity="0" width="4.16666666667" x="62.5" y="0"/>
-      <text class="num9" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 17.19 maf</text>
-      <text class="num9" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1915</text>
-      <text class="num9" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 13.62 maf</text>
+      <text class="num9" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 17.19 maf</text>
+      <text class="num9" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1915</text>
+      <text class="num9" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 13.62 maf</text>
       <rect class="linebox" fill="black" height="250" id="box10" opacity="0" width="4.16666666667" x="66.6666666667" y="0"/>
-      <text class="num10" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 17.33 maf</text>
-      <text class="num10" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1916</text>
-      <text class="num10" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 20.14 maf</text>
+      <text class="num10" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 17.33 maf</text>
+      <text class="num10" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1916</text>
+      <text class="num10" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 20.14 maf</text>
       <rect class="linebox" fill="black" height="250" id="box11" opacity="0" width="4.16666666667" x="70.8333333333" y="0"/>
-      <text class="num11" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 17.54 maf</text>
-      <text class="num11" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1917</text>
-      <text class="num11" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 22.94 maf</text>
+      <text class="num11" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 17.54 maf</text>
+      <text class="num11" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1917</text>
+      <text class="num11" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 22.94 maf</text>
       <rect class="linebox" fill="black" height="250" id="box12" opacity="0" width="4.16666666667" x="75.0" y="0"/>
-      <text class="num12" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 17.95 maf</text>
-      <text class="num12" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1918</text>
-      <text class="num12" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 15.87 maf</text>
+      <text class="num12" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 17.95 maf</text>
+      <text class="num12" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1918</text>
+      <text class="num12" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 15.87 maf</text>
       <rect class="linebox" fill="black" height="250" id="box13" opacity="0" width="4.16666666667" x="79.1666666667" y="0"/>
-      <text class="num13" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 17.0 maf</text>
-      <text class="num13" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1919</text>
-      <text class="num13" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 12.65 maf</text>
+      <text class="num13" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 17.0 maf</text>
+      <text class="num13" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1919</text>
+      <text class="num13" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 12.65 maf</text>
       <rect class="linebox" fill="black" height="250" id="box14" opacity="0" width="4.16666666667" x="83.3333333333" y="0"/>
-      <text class="num14" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 17.77 maf</text>
-      <text class="num14" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1920</text>
-      <text class="num14" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 22.29 maf</text>
+      <text class="num14" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 17.77 maf</text>
+      <text class="num14" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1920</text>
+      <text class="num14" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 22.29 maf</text>
       <rect class="linebox" fill="black" height="250" id="box15" opacity="0" width="4.16666666667" x="87.5" y="0"/>
-      <text class="num15" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 18.46 maf</text>
-      <text class="num15" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1921</text>
-      <text class="num15" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 22.53 maf</text>
+      <text class="num15" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 18.46 maf</text>
+      <text class="num15" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1921</text>
+      <text class="num15" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 22.53 maf</text>
       <rect class="linebox" fill="black" height="250" id="box16" opacity="0" width="4.16666666667" x="91.6666666667" y="0"/>
-      <text class="num16" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 18.44 maf</text>
-      <text class="num16" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1922</text>
-      <text class="num16" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 18.45 maf</text>
+      <text class="num16" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 18.44 maf</text>
+      <text class="num16" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1922</text>
+      <text class="num16" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 18.45 maf</text>
       <rect class="linebox" fill="black" height="250" id="box17" opacity="0" width="4.16666666667" x="95.8333333333" y="0"/>
-      <text class="num17" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 18.89 maf</text>
-      <text class="num17" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1923</text>
-      <text class="num17" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 19.02 maf</text>
+      <text class="num17" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 18.89 maf</text>
+      <text class="num17" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1923</text>
+      <text class="num17" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 19.02 maf</text>
       <rect class="linebox" fill="black" height="250" id="box18" opacity="0" width="4.16666666667" x="100.0" y="0"/>
-      <text class="num18" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 18.14 maf</text>
-      <text class="num18" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1924</text>
-      <text class="num18" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 13.88 maf</text>
+      <text class="num18" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 18.14 maf</text>
+      <text class="num18" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1924</text>
+      <text class="num18" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 13.88 maf</text>
       <rect class="linebox" fill="black" height="250" id="box19" opacity="0" width="4.16666666667" x="104.166666667" y="0"/>
-      <text class="num19" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 18.22 maf</text>
-      <text class="num19" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1925</text>
-      <text class="num19" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 14.43 maf</text>
+      <text class="num19" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 18.22 maf</text>
+      <text class="num19" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1925</text>
+      <text class="num19" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 14.43 maf</text>
       <rect class="linebox" fill="black" height="250" id="box20" opacity="0" width="4.16666666667" x="108.333333333" y="0"/>
-      <text class="num20" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 17.73 maf</text>
-      <text class="num20" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1926</text>
-      <text class="num20" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 15.21 maf</text>
+      <text class="num20" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 17.73 maf</text>
+      <text class="num20" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1926</text>
+      <text class="num20" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 15.21 maf</text>
       <rect class="linebox" fill="black" height="250" id="box21" opacity="0" width="4.16666666667" x="112.5" y="0"/>
-      <text class="num21" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 17.39 maf</text>
-      <text class="num21" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1927</text>
-      <text class="num21" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 19.54 maf</text>
+      <text class="num21" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 17.39 maf</text>
+      <text class="num21" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1927</text>
+      <text class="num21" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 19.54 maf</text>
       <rect class="linebox" fill="black" height="250" id="box22" opacity="0" width="4.16666666667" x="116.666666667" y="0"/>
-      <text class="num22" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 17.5 maf</text>
-      <text class="num22" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1928</text>
-      <text class="num22" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 16.95 maf</text>
+      <text class="num22" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 17.5 maf</text>
+      <text class="num22" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1928</text>
+      <text class="num22" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 16.95 maf</text>
       <rect class="linebox" fill="black" height="250" id="box23" opacity="0" width="4.16666666667" x="120.833333333" y="0"/>
-      <text class="num23" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 18.41 maf</text>
-      <text class="num23" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1929</text>
-      <text class="num23" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 21.83 maf</text>
+      <text class="num23" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 18.41 maf</text>
+      <text class="num23" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1929</text>
+      <text class="num23" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 21.83 maf</text>
       <rect class="linebox" fill="black" height="250" id="box24" opacity="0" width="4.16666666667" x="125.0" y="0"/>
-      <text class="num24" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 17.65 maf</text>
-      <text class="num24" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1930</text>
-      <text class="num24" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 14.62 maf</text>
+      <text class="num24" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 17.65 maf</text>
+      <text class="num24" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1930</text>
+      <text class="num24" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 14.62 maf</text>
       <rect class="linebox" fill="black" height="250" id="box25" opacity="0" width="4.16666666667" x="129.166666667" y="0"/>
-      <text class="num25" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 16.24 maf</text>
-      <text class="num25" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1931</text>
-      <text class="num25" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 8.47 maf</text>
+      <text class="num25" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 16.24 maf</text>
+      <text class="num25" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1931</text>
+      <text class="num25" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 8.47 maf</text>
       <rect class="linebox" fill="black" height="250" id="box26" opacity="0" width="4.16666666667" x="133.333333333" y="0"/>
-      <text class="num26" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 16.14 maf</text>
-      <text class="num26" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1932</text>
-      <text class="num26" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 17.42 maf</text>
+      <text class="num26" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 16.14 maf</text>
+      <text class="num26" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1932</text>
+      <text class="num26" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 17.42 maf</text>
       <rect class="linebox" fill="black" height="250" id="box27" opacity="0" width="4.16666666667" x="137.5" y="0"/>
-      <text class="num27" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 15.45 maf</text>
-      <text class="num27" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1933</text>
-      <text class="num27" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 12.18 maf</text>
+      <text class="num27" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 15.45 maf</text>
+      <text class="num27" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1933</text>
+      <text class="num27" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 12.18 maf</text>
       <rect class="linebox" fill="black" height="250" id="box28" opacity="0" width="4.16666666667" x="141.666666667" y="0"/>
-      <text class="num28" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 14.68 maf</text>
-      <text class="num28" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1934</text>
-      <text class="num28" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 6.18 maf</text>
+      <text class="num28" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 14.68 maf</text>
+      <text class="num28" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1934</text>
+      <text class="num28" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 6.18 maf</text>
       <rect class="linebox" fill="black" height="250" id="box29" opacity="0" width="4.16666666667" x="145.833333333" y="0"/>
-      <text class="num29" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 14.5 maf</text>
-      <text class="num29" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1935</text>
-      <text class="num29" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 12.63 maf</text>
+      <text class="num29" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 14.5 maf</text>
+      <text class="num29" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1935</text>
+      <text class="num29" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 12.63 maf</text>
       <rect class="linebox" fill="black" height="250" id="box30" opacity="0" width="4.16666666667" x="150.0" y="0"/>
-      <text class="num30" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 14.45 maf</text>
-      <text class="num30" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1936</text>
-      <text class="num30" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 14.65 maf</text>
+      <text class="num30" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 14.45 maf</text>
+      <text class="num30" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1936</text>
+      <text class="num30" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 14.65 maf</text>
       <rect class="linebox" fill="black" height="250" id="box31" opacity="0" width="4.16666666667" x="154.166666667" y="0"/>
-      <text class="num31" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 13.92 maf</text>
-      <text class="num31" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1937</text>
-      <text class="num31" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 14.31 maf</text>
+      <text class="num31" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 13.92 maf</text>
+      <text class="num31" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1937</text>
+      <text class="num31" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 14.31 maf</text>
       <rect class="linebox" fill="black" height="250" id="box32" opacity="0" width="4.16666666667" x="158.333333333" y="0"/>
-      <text class="num32" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 14.04 maf</text>
-      <text class="num32" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1938</text>
-      <text class="num32" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 18.15 maf</text>
+      <text class="num32" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 14.04 maf</text>
+      <text class="num32" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1938</text>
+      <text class="num32" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 18.15 maf</text>
       <rect class="linebox" fill="black" height="250" id="box33" opacity="0" width="4.16666666667" x="162.5" y="0"/>
-      <text class="num33" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 12.98 maf</text>
-      <text class="num33" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1939</text>
-      <text class="num33" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 11.16 maf</text>
+      <text class="num33" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 12.98 maf</text>
+      <text class="num33" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1939</text>
+      <text class="num33" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 11.16 maf</text>
       <rect class="linebox" fill="black" height="250" id="box34" opacity="0" width="4.16666666667" x="166.666666667" y="0"/>
-      <text class="num34" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 12.51 maf</text>
-      <text class="num34" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1940</text>
-      <text class="num34" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 9.93 maf</text>
+      <text class="num34" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 12.51 maf</text>
+      <text class="num34" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1940</text>
+      <text class="num34" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 9.93 maf</text>
       <rect class="linebox" fill="black" height="250" id="box35" opacity="0" width="4.16666666667" x="170.833333333" y="0"/>
-      <text class="num35" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 13.67 maf</text>
-      <text class="num35" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1941</text>
-      <text class="num35" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 20.12 maf</text>
+      <text class="num35" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 13.67 maf</text>
+      <text class="num35" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1941</text>
+      <text class="num35" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 20.12 maf</text>
       <rect class="linebox" fill="black" height="250" id="box36" opacity="0" width="4.16666666667" x="175.0" y="0"/>
-      <text class="num36" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 13.65 maf</text>
-      <text class="num36" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1942</text>
-      <text class="num36" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 17.23 maf</text>
+      <text class="num36" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 13.65 maf</text>
+      <text class="num36" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1942</text>
+      <text class="num36" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 17.23 maf</text>
       <rect class="linebox" fill="black" height="250" id="box37" opacity="0" width="4.16666666667" x="179.166666667" y="0"/>
-      <text class="num37" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 13.81 maf</text>
-      <text class="num37" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1943</text>
-      <text class="num37" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 13.73 maf</text>
+      <text class="num37" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 13.81 maf</text>
+      <text class="num37" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1943</text>
+      <text class="num37" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 13.73 maf</text>
       <rect class="linebox" fill="black" height="250" id="box38" opacity="0" width="4.16666666667" x="183.333333333" y="0"/>
-      <text class="num38" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 14.73 maf</text>
-      <text class="num38" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1944</text>
-      <text class="num38" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 15.37 maf</text>
+      <text class="num38" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 14.73 maf</text>
+      <text class="num38" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1944</text>
+      <text class="num38" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 15.37 maf</text>
       <rect class="linebox" fill="black" height="250" id="box39" opacity="0" width="4.16666666667" x="187.5" y="0"/>
-      <text class="num39" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 14.88 maf</text>
-      <text class="num39" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1945</text>
-      <text class="num39" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 14.14 maf</text>
+      <text class="num39" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 14.88 maf</text>
+      <text class="num39" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1945</text>
+      <text class="num39" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 14.14 maf</text>
       <rect class="linebox" fill="black" height="250" id="box40" opacity="0" width="4.16666666667" x="191.666666667" y="0"/>
-      <text class="num40" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 14.52 maf</text>
-      <text class="num40" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1946</text>
-      <text class="num40" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 11.1 maf</text>
+      <text class="num40" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 14.52 maf</text>
+      <text class="num40" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1946</text>
+      <text class="num40" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 11.1 maf</text>
       <rect class="linebox" fill="black" height="250" id="box41" opacity="0" width="4.16666666667" x="195.833333333" y="0"/>
-      <text class="num41" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 14.74 maf</text>
-      <text class="num41" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1947</text>
-      <text class="num41" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 16.44 maf</text>
+      <text class="num41" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 14.74 maf</text>
+      <text class="num41" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1947</text>
+      <text class="num41" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 16.44 maf</text>
       <rect class="linebox" fill="black" height="250" id="box42" opacity="0" width="4.16666666667" x="200.0" y="0"/>
-      <text class="num42" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 14.44 maf</text>
-      <text class="num42" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1948</text>
-      <text class="num42" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 15.14 maf</text>
+      <text class="num42" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 14.44 maf</text>
+      <text class="num42" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1948</text>
+      <text class="num42" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 15.14 maf</text>
       <rect class="linebox" fill="black" height="250" id="box43" opacity="0" width="4.16666666667" x="204.166666667" y="0"/>
-      <text class="num43" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 15.01 maf</text>
-      <text class="num43" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1949</text>
-      <text class="num43" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 16.93 maf</text>
+      <text class="num43" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 15.01 maf</text>
+      <text class="num43" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1949</text>
+      <text class="num43" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 16.93 maf</text>
       <rect class="linebox" fill="black" height="250" id="box44" opacity="0" width="4.16666666667" x="208.333333333" y="0"/>
-      <text class="num44" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 15.33 maf</text>
-      <text class="num44" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1950</text>
-      <text class="num44" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 13.14 maf</text>
+      <text class="num44" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 15.33 maf</text>
+      <text class="num44" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1950</text>
+      <text class="num44" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 13.14 maf</text>
       <rect class="linebox" fill="black" height="250" id="box45" opacity="0" width="4.16666666667" x="212.5" y="0"/>
-      <text class="num45" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 14.57 maf</text>
-      <text class="num45" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1951</text>
-      <text class="num45" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 12.51 maf</text>
+      <text class="num45" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 14.57 maf</text>
+      <text class="num45" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1951</text>
+      <text class="num45" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 12.51 maf</text>
       <rect class="linebox" fill="black" height="250" id="box46" opacity="0" width="4.16666666667" x="216.666666667" y="0"/>
-      <text class="num46" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 14.93 maf</text>
-      <text class="num46" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1952</text>
-      <text class="num46" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 20.81 maf</text>
+      <text class="num46" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 14.93 maf</text>
+      <text class="num46" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1952</text>
+      <text class="num46" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 20.81 maf</text>
       <rect class="linebox" fill="black" height="250" id="box47" opacity="0" width="4.16666666667" x="220.833333333" y="0"/>
-      <text class="num47" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 14.67 maf</text>
-      <text class="num47" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1953</text>
-      <text class="num47" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 11.17 maf</text>
+      <text class="num47" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 14.67 maf</text>
+      <text class="num47" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1953</text>
+      <text class="num47" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 11.17 maf</text>
       <rect class="linebox" fill="black" height="250" id="box48" opacity="0" width="4.16666666667" x="225.0" y="0"/>
-      <text class="num48" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 13.99 maf</text>
-      <text class="num48" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1954</text>
-      <text class="num48" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 8.5 maf</text>
+      <text class="num48" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 13.99 maf</text>
+      <text class="num48" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1954</text>
+      <text class="num48" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 8.5 maf</text>
       <rect class="linebox" fill="black" height="250" id="box49" opacity="0" width="4.16666666667" x="229.166666667" y="0"/>
-      <text class="num49" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 13.51 maf</text>
-      <text class="num49" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1955</text>
-      <text class="num49" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 9.41 maf</text>
+      <text class="num49" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 13.51 maf</text>
+      <text class="num49" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1955</text>
+      <text class="num49" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 9.41 maf</text>
       <rect class="linebox" fill="black" height="250" id="box50" opacity="0" width="4.16666666667" x="233.333333333" y="0"/>
-      <text class="num50" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 13.55 maf</text>
-      <text class="num50" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1956</text>
-      <text class="num50" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 11.43 maf</text>
+      <text class="num50" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 13.55 maf</text>
+      <text class="num50" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1956</text>
+      <text class="num50" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 11.43 maf</text>
       <rect class="linebox" fill="black" height="250" id="box51" opacity="0" width="4.16666666667" x="237.5" y="0"/>
-      <text class="num51" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 14.05 maf</text>
-      <text class="num51" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1957</text>
-      <text class="num51" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 21.5 maf</text>
+      <text class="num51" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 14.05 maf</text>
+      <text class="num51" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1957</text>
+      <text class="num51" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 21.5 maf</text>
       <rect class="linebox" fill="black" height="250" id="box52" opacity="0" width="4.16666666667" x="241.666666667" y="0"/>
-      <text class="num52" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 14.13 maf</text>
-      <text class="num52" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1958</text>
-      <text class="num52" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 15.86 maf</text>
+      <text class="num52" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 14.13 maf</text>
+      <text class="num52" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1958</text>
+      <text class="num52" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 15.86 maf</text>
       <rect class="linebox" fill="black" height="250" id="box53" opacity="0" width="4.16666666667" x="245.833333333" y="0"/>
-      <text class="num53" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 13.39 maf</text>
-      <text class="num53" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1959</text>
-      <text class="num53" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 9.6 maf</text>
+      <text class="num53" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 13.39 maf</text>
+      <text class="num53" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1959</text>
+      <text class="num53" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 9.6 maf</text>
       <rect class="linebox" fill="black" height="250" id="box54" opacity="0" width="4.16666666667" x="250.0" y="0"/>
-      <text class="num54" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 13.23 maf</text>
-      <text class="num54" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1960</text>
-      <text class="num54" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 11.52 maf</text>
+      <text class="num54" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 13.23 maf</text>
+      <text class="num54" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1960</text>
+      <text class="num54" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 11.52 maf</text>
       <rect class="linebox" fill="black" height="250" id="box55" opacity="0" width="4.16666666667" x="254.166666667" y="0"/>
-      <text class="num55" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 12.98 maf</text>
-      <text class="num55" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1961</text>
-      <text class="num55" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 10.01 maf</text>
+      <text class="num55" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 12.98 maf</text>
+      <text class="num55" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1961</text>
+      <text class="num55" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 10.01 maf</text>
       <rect class="linebox" fill="black" height="250" id="box56" opacity="0" width="4.16666666667" x="258.333333333" y="0"/>
-      <text class="num56" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 12.64 maf</text>
-      <text class="num56" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1962</text>
-      <text class="num56" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 17.38 maf</text>
+      <text class="num56" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 12.64 maf</text>
+      <text class="num56" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1962</text>
+      <text class="num56" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 17.38 maf</text>
       <rect class="linebox" fill="black" height="250" id="box57" opacity="0" width="4.16666666667" x="262.5" y="0"/>
-      <text class="num57" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 12.39 maf</text>
-      <text class="num57" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1963</text>
-      <text class="num57" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 8.67 maf</text>
+      <text class="num57" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 12.39 maf</text>
+      <text class="num57" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1963</text>
+      <text class="num57" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 8.67 maf</text>
       <rect class="linebox" fill="black" height="250" id="box58" opacity="0" width="4.16666666667" x="266.666666667" y="0"/>
-      <text class="num58" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 12.58 maf</text>
-      <text class="num58" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1964</text>
-      <text class="num58" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 10.38 maf</text>
+      <text class="num58" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 12.58 maf</text>
+      <text class="num58" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1964</text>
+      <text class="num58" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 10.38 maf</text>
       <rect class="linebox" fill="black" height="250" id="box59" opacity="0" width="4.16666666667" x="270.833333333" y="0"/>
-      <text class="num59" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 13.59 maf</text>
-      <text class="num59" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1965</text>
-      <text class="num59" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 19.52 maf</text>
+      <text class="num59" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 13.59 maf</text>
+      <text class="num59" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1965</text>
+      <text class="num59" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 19.52 maf</text>
       <rect class="linebox" fill="black" height="250" id="box60" opacity="0" width="4.16666666667" x="275.0" y="0"/>
-      <text class="num60" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 13.47 maf</text>
-      <text class="num60" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1966</text>
-      <text class="num60" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 10.23 maf</text>
+      <text class="num60" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 13.47 maf</text>
+      <text class="num60" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1966</text>
+      <text class="num60" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 10.23 maf</text>
       <rect class="linebox" fill="black" height="250" id="box61" opacity="0" width="4.16666666667" x="279.166666667" y="0"/>
-      <text class="num61" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 12.47 maf</text>
-      <text class="num61" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1967</text>
-      <text class="num61" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 11.57 maf</text>
+      <text class="num61" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 12.47 maf</text>
+      <text class="num61" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1967</text>
+      <text class="num61" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 11.57 maf</text>
       <rect class="linebox" fill="black" height="250" id="box62" opacity="0" width="4.16666666667" x="283.333333333" y="0"/>
-      <text class="num62" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 12.25 maf</text>
-      <text class="num62" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1968</text>
-      <text class="num62" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 13.63 maf</text>
+      <text class="num62" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 12.25 maf</text>
+      <text class="num62" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1968</text>
+      <text class="num62" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 13.63 maf</text>
       <rect class="linebox" fill="black" height="250" id="box63" opacity="0" width="4.16666666667" x="287.5" y="0"/>
-      <text class="num63" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 12.79 maf</text>
-      <text class="num63" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1969</text>
-      <text class="num63" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 15.01 maf</text>
+      <text class="num63" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 12.79 maf</text>
+      <text class="num63" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1969</text>
+      <text class="num63" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 15.01 maf</text>
       <rect class="linebox" fill="black" height="250" id="box64" opacity="0" width="4.16666666667" x="291.666666667" y="0"/>
-      <text class="num64" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 13.13 maf</text>
-      <text class="num64" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1970</text>
-      <text class="num64" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 14.95 maf</text>
+      <text class="num64" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 13.13 maf</text>
+      <text class="num64" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1970</text>
+      <text class="num64" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 14.95 maf</text>
       <rect class="linebox" fill="black" height="250" id="box65" opacity="0" width="4.16666666667" x="295.833333333" y="0"/>
-      <text class="num65" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 13.63 maf</text>
-      <text class="num65" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1971</text>
-      <text class="num65" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 14.99 maf</text>
+      <text class="num65" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 13.63 maf</text>
+      <text class="num65" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1971</text>
+      <text class="num65" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 14.99 maf</text>
       <rect class="linebox" fill="black" height="250" id="box66" opacity="0" width="4.16666666667" x="300.0" y="0"/>
-      <text class="num66" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 13.2 maf</text>
-      <text class="num66" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1972</text>
-      <text class="num66" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 13.12 maf</text>
+      <text class="num66" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 13.2 maf</text>
+      <text class="num66" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1972</text>
+      <text class="num66" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 13.12 maf</text>
       <rect class="linebox" fill="black" height="250" id="box67" opacity="0" width="4.16666666667" x="304.166666667" y="0"/>
-      <text class="num67" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 14.15 maf</text>
-      <text class="num67" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1973</text>
-      <text class="num67" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 18.16 maf</text>
+      <text class="num67" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 14.15 maf</text>
+      <text class="num67" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1973</text>
+      <text class="num67" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 18.16 maf</text>
       <rect class="linebox" fill="black" height="250" id="box68" opacity="0" width="4.16666666667" x="308.333333333" y="0"/>
-      <text class="num68" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 14.41 maf</text>
-      <text class="num68" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1974</text>
-      <text class="num68" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 12.92 maf</text>
+      <text class="num68" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 14.41 maf</text>
+      <text class="num68" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1974</text>
+      <text class="num68" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 12.92 maf</text>
       <rect class="linebox" fill="black" height="250" id="box69" opacity="0" width="4.16666666667" x="312.5" y="0"/>
-      <text class="num69" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 14.11 maf</text>
-      <text class="num69" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1975</text>
-      <text class="num69" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 16.53 maf</text>
+      <text class="num69" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 14.11 maf</text>
+      <text class="num69" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1975</text>
+      <text class="num69" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 16.53 maf</text>
       <rect class="linebox" fill="black" height="250" id="box70" opacity="0" width="4.16666666667" x="316.666666667" y="0"/>
-      <text class="num70" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 14.19 maf</text>
-      <text class="num70" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1976</text>
-      <text class="num70" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 11.04 maf</text>
+      <text class="num70" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 14.19 maf</text>
+      <text class="num70" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1976</text>
+      <text class="num70" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 11.04 maf</text>
       <rect class="linebox" fill="black" height="250" id="box71" opacity="0" width="4.16666666667" x="320.833333333" y="0"/>
-      <text class="num71" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 13.57 maf</text>
-      <text class="num71" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1977</text>
-      <text class="num71" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 5.36 maf</text>
+      <text class="num71" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 13.57 maf</text>
+      <text class="num71" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1977</text>
+      <text class="num71" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 5.36 maf</text>
       <rect class="linebox" fill="black" height="250" id="box72" opacity="0" width="4.16666666667" x="325.0" y="0"/>
-      <text class="num72" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 13.72 maf</text>
-      <text class="num72" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1978</text>
-      <text class="num72" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 15.14 maf</text>
+      <text class="num72" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 13.72 maf</text>
+      <text class="num72" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1978</text>
+      <text class="num72" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 15.14 maf</text>
       <rect class="linebox" fill="black" height="250" id="box73" opacity="0" width="4.16666666667" x="329.166666667" y="0"/>
-      <text class="num73" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 13.96 maf</text>
-      <text class="num73" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1979</text>
-      <text class="num73" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 17.43 maf</text>
+      <text class="num73" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 13.96 maf</text>
+      <text class="num73" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1979</text>
+      <text class="num73" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 17.43 maf</text>
       <rect class="linebox" fill="black" height="250" id="box74" opacity="0" width="4.16666666667" x="333.333333333" y="0"/>
-      <text class="num74" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 14.21 maf</text>
-      <text class="num74" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1980</text>
-      <text class="num74" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 17.44 maf</text>
+      <text class="num74" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 14.21 maf</text>
+      <text class="num74" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1980</text>
+      <text class="num74" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 17.44 maf</text>
       <rect class="linebox" fill="black" height="250" id="box75" opacity="0" width="4.16666666667" x="337.5" y="0"/>
-      <text class="num75" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 13.6 maf</text>
-      <text class="num75" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1981</text>
-      <text class="num75" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 8.9 maf</text>
+      <text class="num75" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 13.6 maf</text>
+      <text class="num75" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1981</text>
+      <text class="num75" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 8.9 maf</text>
       <rect class="linebox" fill="black" height="250" id="box76" opacity="0" width="4.16666666667" x="341.666666667" y="0"/>
-      <text class="num76" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 14.02 maf</text>
-      <text class="num76" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1982</text>
-      <text class="num76" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 17.31 maf</text>
+      <text class="num76" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 14.02 maf</text>
+      <text class="num76" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1982</text>
+      <text class="num76" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 17.31 maf</text>
       <rect class="linebox" fill="black" height="250" id="box77" opacity="0" width="4.16666666667" x="345.833333333" y="0"/>
-      <text class="num77" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 14.57 maf</text>
-      <text class="num77" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1983</text>
-      <text class="num77" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 23.59 maf</text>
+      <text class="num77" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 14.57 maf</text>
+      <text class="num77" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1983</text>
+      <text class="num77" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 23.59 maf</text>
       <rect class="linebox" fill="black" height="250" id="box78" opacity="0" width="4.16666666667" x="350.0" y="0"/>
-      <text class="num78" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 15.71 maf</text>
-      <text class="num78" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1984</text>
-      <text class="num78" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 24.34 maf</text>
+      <text class="num78" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 15.71 maf</text>
+      <text class="num78" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1984</text>
+      <text class="num78" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 24.34 maf</text>
       <rect class="linebox" fill="black" height="250" id="box79" opacity="0" width="4.16666666667" x="354.166666667" y="0"/>
-      <text class="num79" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 16.15 maf</text>
-      <text class="num79" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1985</text>
-      <text class="num79" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 20.99 maf</text>
+      <text class="num79" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 16.15 maf</text>
+      <text class="num79" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1985</text>
+      <text class="num79" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 20.99 maf</text>
       <rect class="linebox" fill="black" height="250" id="box80" opacity="0" width="4.16666666667" x="358.333333333" y="0"/>
-      <text class="num80" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 17.34 maf</text>
-      <text class="num80" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1986</text>
-      <text class="num80" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 22.95 maf</text>
+      <text class="num80" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 17.34 maf</text>
+      <text class="num80" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1986</text>
+      <text class="num80" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 22.95 maf</text>
       <rect class="linebox" fill="black" height="250" id="box81" opacity="0" width="4.16666666667" x="362.5" y="0"/>
-      <text class="num81" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 18.34 maf</text>
-      <text class="num81" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1987</text>
-      <text class="num81" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 15.27 maf</text>
+      <text class="num81" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 18.34 maf</text>
+      <text class="num81" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1987</text>
+      <text class="num81" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 15.27 maf</text>
       <rect class="linebox" fill="black" height="250" id="box82" opacity="0" width="4.16666666667" x="366.666666667" y="0"/>
-      <text class="num82" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 17.94 maf</text>
-      <text class="num82" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1988</text>
-      <text class="num82" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 11.14 maf</text>
+      <text class="num82" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 17.94 maf</text>
+      <text class="num82" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1988</text>
+      <text class="num82" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 11.14 maf</text>
       <rect class="linebox" fill="black" height="250" id="box83" opacity="0" width="4.16666666667" x="370.833333333" y="0"/>
-      <text class="num83" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 17.14 maf</text>
-      <text class="num83" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1989</text>
-      <text class="num83" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 9.43 maf</text>
+      <text class="num83" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 17.14 maf</text>
+      <text class="num83" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1989</text>
+      <text class="num83" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 9.43 maf</text>
       <rect class="linebox" fill="black" height="250" id="box84" opacity="0" width="4.16666666667" x="375.0" y="0"/>
-      <text class="num84" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 16.32 maf</text>
-      <text class="num84" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1990</text>
-      <text class="num84" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 9.32 maf</text>
+      <text class="num84" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 16.32 maf</text>
+      <text class="num84" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1990</text>
+      <text class="num84" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 9.32 maf</text>
       <rect class="linebox" fill="black" height="250" id="box85" opacity="0" width="4.16666666667" x="379.166666667" y="0"/>
-      <text class="num85" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 16.66 maf</text>
-      <text class="num85" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1991</text>
-      <text class="num85" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 12.3 maf</text>
+      <text class="num85" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 16.66 maf</text>
+      <text class="num85" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1991</text>
+      <text class="num85" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 12.3 maf</text>
       <rect class="linebox" fill="black" height="250" id="box86" opacity="0" width="4.16666666667" x="383.333333333" y="0"/>
-      <text class="num86" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 16.03 maf</text>
-      <text class="num86" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1992</text>
-      <text class="num86" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 10.92 maf</text>
+      <text class="num86" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 16.03 maf</text>
+      <text class="num86" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1992</text>
+      <text class="num86" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 10.92 maf</text>
       <rect class="linebox" fill="black" height="250" id="box87" opacity="0" width="4.16666666667" x="387.5" y="0"/>
-      <text class="num87" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 15.56 maf</text>
-      <text class="num87" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1993</text>
-      <text class="num87" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 18.88 maf</text>
+      <text class="num87" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 15.56 maf</text>
+      <text class="num87" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1993</text>
+      <text class="num87" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 18.88 maf</text>
       <rect class="linebox" fill="black" height="250" id="box88" opacity="0" width="4.16666666667" x="391.666666667" y="0"/>
-      <text class="num88" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 14.17 maf</text>
-      <text class="num88" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1994</text>
-      <text class="num88" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 10.54 maf</text>
+      <text class="num88" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 14.17 maf</text>
+      <text class="num88" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1994</text>
+      <text class="num88" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 10.54 maf</text>
       <rect class="linebox" fill="black" height="250" id="box89" opacity="0" width="4.16666666667" x="395.833333333" y="0"/>
-      <text class="num89" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 14.07 maf</text>
-      <text class="num89" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1995</text>
-      <text class="num89" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 19.97 maf</text>
+      <text class="num89" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 14.07 maf</text>
+      <text class="num89" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1995</text>
+      <text class="num89" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 19.97 maf</text>
       <rect class="linebox" fill="black" height="250" id="box90" opacity="0" width="4.16666666667" x="400.0" y="0"/>
-      <text class="num90" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 13.2 maf</text>
-      <text class="num90" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1996</text>
-      <text class="num90" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 14.2 maf</text>
+      <text class="num90" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 13.2 maf</text>
+      <text class="num90" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1996</text>
+      <text class="num90" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 14.2 maf</text>
       <rect class="linebox" fill="black" height="250" id="box91" opacity="0" width="4.16666666667" x="404.166666667" y="0"/>
-      <text class="num91" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 13.84 maf</text>
-      <text class="num91" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1997</text>
-      <text class="num91" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 21.66 maf</text>
+      <text class="num91" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 13.84 maf</text>
+      <text class="num91" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1997</text>
+      <text class="num91" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 21.66 maf</text>
       <rect class="linebox" fill="black" height="250" id="box92" opacity="0" width="4.16666666667" x="408.333333333" y="0"/>
-      <text class="num92" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 14.39 maf</text>
-      <text class="num92" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1998</text>
-      <text class="num92" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 16.69 maf</text>
+      <text class="num92" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 14.39 maf</text>
+      <text class="num92" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1998</text>
+      <text class="num92" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 16.69 maf</text>
       <rect class="linebox" fill="black" height="250" id="box93" opacity="0" width="4.16666666667" x="412.5" y="0"/>
-      <text class="num93" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 15.03 maf</text>
-      <text class="num93" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 1999</text>
-      <text class="num93" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 15.83 maf</text>
+      <text class="num93" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 15.03 maf</text>
+      <text class="num93" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 1999</text>
+      <text class="num93" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 15.83 maf</text>
       <rect class="linebox" fill="black" height="250" id="box94" opacity="0" width="4.16666666667" x="416.666666667" y="0"/>
-      <text class="num94" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 15.15 maf</text>
-      <text class="num94" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 2000</text>
-      <text class="num94" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 10.51 maf</text>
+      <text class="num94" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 15.15 maf</text>
+      <text class="num94" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 2000</text>
+      <text class="num94" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 10.51 maf</text>
       <rect class="linebox" fill="black" height="250" id="box95" opacity="0" width="4.16666666667" x="420.833333333" y="0"/>
-      <text class="num95" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 14.99 maf</text>
-      <text class="num95" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 2001</text>
-      <text class="num95" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 10.72 maf</text>
+      <text class="num95" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 14.99 maf</text>
+      <text class="num95" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 2001</text>
+      <text class="num95" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 10.72 maf</text>
       <rect class="linebox" fill="black" height="250" id="box96" opacity="0" width="4.16666666667" x="425.0" y="0"/>
-      <text class="num96" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 14.5 maf</text>
-      <text class="num96" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 2002</text>
-      <text class="num96" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 6.03 maf</text>
+      <text class="num96" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 14.5 maf</text>
+      <text class="num96" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 2002</text>
+      <text class="num96" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 6.03 maf</text>
       <rect class="linebox" fill="black" height="250" id="box97" opacity="0" width="4.16666666667" x="429.166666667" y="0"/>
-      <text class="num97" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 13.66 maf</text>
-      <text class="num97" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 2003</text>
-      <text class="num97" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 10.5 maf</text>
+      <text class="num97" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 13.66 maf</text>
+      <text class="num97" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 2003</text>
+      <text class="num97" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 10.5 maf</text>
       <rect class="linebox" fill="black" height="250" id="box98" opacity="0" width="4.16666666667" x="433.333333333" y="0"/>
-      <text class="num98" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 13.6 maf</text>
-      <text class="num98" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 2004</text>
-      <text class="num98" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 9.9 maf</text>
+      <text class="num98" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 13.6 maf</text>
+      <text class="num98" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 2004</text>
+      <text class="num98" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 9.9 maf</text>
       <rect class="linebox" fill="black" height="250" id="box99" opacity="0" width="4.16666666667" x="437.5" y="0"/>
-      <text class="num99" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 13.31 maf</text>
-      <text class="num99" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 2005</text>
-      <text class="num99" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 17.08 maf</text>
+      <text class="num99" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 13.31 maf</text>
+      <text class="num99" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 2005</text>
+      <text class="num99" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 17.08 maf</text>
       <rect class="linebox" fill="black" height="250" id="box100" opacity="0" width="4.16666666667" x="441.666666667" y="0"/>
-      <text class="num100" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 13.24 maf</text>
-      <text class="num100" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 2006</text>
-      <text class="num100" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 13.52 maf</text>
+      <text class="num100" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 13.24 maf</text>
+      <text class="num100" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 2006</text>
+      <text class="num100" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 13.52 maf</text>
       <rect class="linebox" fill="black" height="250" id="box101" opacity="0" width="4.16666666667" x="445.833333333" y="0"/>
-      <text class="num101" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 12.22 maf</text>
-      <text class="num101" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 2007</text>
-      <text class="num101" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 11.38 maf</text>
+      <text class="num101" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 12.22 maf</text>
+      <text class="num101" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 2007</text>
+      <text class="num101" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 11.38 maf</text>
       <rect class="linebox" fill="black" height="250" id="box102" opacity="0" width="4.16666666667" x="450.0" y="0"/>
-      <text class="num102" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 12.16 maf</text>
-      <text class="num102" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 2008</text>
-      <text class="num102" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 16.09 maf</text>
+      <text class="num102" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 12.16 maf</text>
+      <text class="num102" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 2008</text>
+      <text class="num102" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 16.09 maf</text>
       <rect class="linebox" fill="black" height="250" id="box103" opacity="0" width="4.16666666667" x="454.166666667" y="0"/>
-      <text class="num103" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 11.98 maf</text>
-      <text class="num103" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 2009</text>
-      <text class="num103" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 14.1 maf</text>
+      <text class="num103" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 11.98 maf</text>
+      <text class="num103" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 2009</text>
+      <text class="num103" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 14.1 maf</text>
       <rect class="linebox" fill="black" height="250" id="box104" opacity="0" width="4.16666666667" x="458.333333333" y="0"/>
-      <text class="num104" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 12.2 maf</text>
-      <text class="num104" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 2010</text>
-      <text class="num104" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 12.72 maf</text>
+      <text class="num104" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 12.2 maf</text>
+      <text class="num104" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 2010</text>
+      <text class="num104" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 12.72 maf</text>
       <rect class="linebox" fill="black" height="250" id="box105" opacity="0" width="4.16666666667" x="462.5" y="0"/>
-      <text class="num105" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 13.15 maf</text>
-      <text class="num105" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 2011</text>
-      <text class="num105" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 20.14 maf</text>
+      <text class="num105" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 13.15 maf</text>
+      <text class="num105" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 2011</text>
+      <text class="num105" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 20.14 maf</text>
       <rect class="linebox" fill="black" height="250" id="box106" opacity="0" width="4.16666666667" x="466.666666667" y="0"/>
-      <text class="num106" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 13.3 maf</text>
-      <text class="num106" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 2012</text>
-      <text class="num106" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 7.55 maf</text>
+      <text class="num106" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 13.3 maf</text>
+      <text class="num106" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 2012</text>
+      <text class="num106" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 7.55 maf</text>
       <rect class="linebox" fill="black" height="250" id="box107" opacity="0" width="4.16666666667" x="470.833333333" y="0"/>
-      <text class="num107" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 13.23 maf</text>
-      <text class="num107" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 2013</text>
-      <text class="num107" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 9.85 maf</text>
+      <text class="num107" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 13.23 maf</text>
+      <text class="num107" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 2013</text>
+      <text class="num107" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 9.85 maf</text>
       <rect class="linebox" fill="black" height="250" id="box108" opacity="0" width="4.16666666667" x="475.0" y="0"/>
-      <text class="num108" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 13.68 maf</text>
-      <text class="num108" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 2014</text>
-      <text class="num108" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 14.41 maf</text>
+      <text class="num108" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 13.68 maf</text>
+      <text class="num108" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 2014</text>
+      <text class="num108" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 14.41 maf</text>
       <rect class="linebox" fill="black" height="250" id="box109" opacity="0" width="4.16666666667" x="479.166666667" y="0"/>
-      <text class="num109" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="245">10-Year Average Flow Volume: 13.4 maf</text>
-      <text class="num109" fill="black" font-size="12" font-weight="bold" opacity="0" x="15" y="15">Year: 2015</text>
-      <text class="num109" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="15" y="230">Annual Flow Volume: 14.27 maf</text>
+      <text class="num109" fill="blue" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="245">Long-Term Running Average: 13.4 maf</text>
+      <text class="num109" fill="black" font-size="12" font-weight="bold" opacity="0" x="96.666666" y="215">Year: 2015</text>
+      <text class="num109" fill="#9999FF" font-size="12" font-weight="bold" opacity="0" stroke="black" stroke-width=".5" x="96.666666" y="230">Annual Flow Volume: 14.27 maf</text>
       <line stroke="black" stroke-width="2" x1="0.0" x2="0.0" y1="250" y2="245"/>
       <text fill="black" x="-20.0" y="270">1900</text>
       <line stroke="black" stroke-width="2" x1="83.3333333333" x2="83.3333333333" y1="250" y2="245"/>

--- a/scripts/python/createTreeRingGraph.py
+++ b/scripts/python/createTreeRingGraph.py
@@ -103,8 +103,8 @@ def renderGraph(ele, floc):
         maxside = math.ceil(float(max)/5) * 5
         botstep = 500 / ((maxbot - minbot)/10)
         sidestep = 250 / ((maxside - minside)/5)
-        drawHighlightBox(ele, 1906, 1922, minbot, maxbot - minbot, '#A3FF75', 'Pre-Compact Period')
-        drawHighlightBox(ele, 2000, 2016, minbot, maxbot - minbot, '#CCCCB2', 'Current Drought Period')
+        drawHighlightBox(ele, 1906, 1922, minbot, maxbot - minbot, '#A3FF75', 'Pre-Compact', 'Period')
+        drawHighlightBox(ele, 2000, 2016, minbot, maxbot - minbot, '#CCCCB2', 'Current Drought', 'Period')
         linecontainer2 = SubElement(ele, 'g')
         linecontainer2.set('stroke', '#9999FF')
         linecontainer2.set('stroke-width', '2')
@@ -162,7 +162,7 @@ def createLineBox(ele, x1, x2, ymin, yrange, avg, raw, year, rot):
         value = ''
     else:
         value = str(round(avg, 2))
-    text1 = drawText(ele, 15, 245, '10-Year Average Flow Volume: ' + value + ' maf')
+    text1 = drawText(ele, 15 + 81.666666, 245, 'Long-Term Running Average: ' + value + ' maf')
     text1.set('fill', 'blue')
     text1.set('opacity', '0')
     text1.set('font-weight', 'bold')
@@ -170,13 +170,13 @@ def createLineBox(ele, x1, x2, ymin, yrange, avg, raw, year, rot):
     text1.set('stroke','black')
     text1.set('stroke-width', '.5')
     text1.set('class', 'num' + str(rot))
-    text2 = drawText(ele, 15, 15, 'Year: ' + str(year))
+    text2 = drawText(ele, 15 + 81.666666, 215, 'Year: ' + str(year))
     text2.set('fill', 'black')
     text2.set('opacity', '0')
     text2.set('font-weight', 'bold')
     text2.set('font-size', '12')
     text2.set('class', 'num' + str(rot))
-    text3 = drawText(ele, 15, 230, 'Annual Flow Volume: ' + str(round(raw, 2))+ ' maf')
+    text3 = drawText(ele, 15 + 81.666666, 230, 'Annual Flow Volume: ' + str(round(raw, 2))+ ' maf')
     text3.set('fill', '#9999FF')
     text3.set('opacity', '0')
     text3.set('font-weight', 'bold')
@@ -193,7 +193,7 @@ def drawMinLine(ele, percdata, pmin, prange):
     drawLine(ele, 15, 250 - ((min - pmin)*(250/prange)), 485, 250 - ((min - pmin)*(250/prange)), 1, 'red')
     drawText(ele, 15, 250 - ((min - pmin)*(250/prange)) - 5, 'Minimum').set('fill', 'red')
     
-def drawHighlightBox(ele, x1, x2, ymin, yrange, color, text):
+def drawHighlightBox(ele, x1, x2, ymin, yrange, color, text1, text2):
     rect = SubElement(ele, 'rect')
     x1 = (x1 - ymin) * (500/yrange)
     x2 = (x2 - ymin) * (500/yrange)
@@ -202,9 +202,12 @@ def drawHighlightBox(ele, x1, x2, ymin, yrange, color, text):
     rect.set('width', str(x2 - x1))
     rect.set('x', str(x1))
     rect.set('fill', color)
-    t = drawText(ele, str(x1+2), str(23), text)
+    t = drawText(ele, str(x1+2), str(10), text1)
     t.set('fill','black')
-    t.set('font-size', '6')
+    t.set('font-size', '8')
+    t = drawText(ele, str(x1+2), str(20), text2)
+    t.set('fill','black')
+    t.set('font-size', '8')
 
 def highlightRange(ele, x1, x2, ymin, yrange):
     rect = SubElement(ele, 'rect')


### PR DESCRIPTION
This finishes off the changes requested by the revision document.
- Label green column as “Pre-Compact Period”
- Label grey column as “Current Drought Period”

This also fixes a small operating system compatibility problem I accidentally created. I know the new labels added on the green and grey columns are small so if @jread-usgs or @lawinslow have any recommendations about where to move them or whatever, I'm open to ideas. 
