### PR TITLE
media querie for tablet background images

### DIFF
--- a/public_html/css/main.css
+++ b/public_html/css/main.css
@@ -720,6 +720,26 @@ nav h3 {
 	}
 }
 
+@media only screen
+	and (min-device-width: 768px)
+	and (max-device-width: 1024px)
+	and (-webkit-min-device-pixel-ratio: 1){
+		#Introduction,
+		#Lifeline,
+		#ControlStructures,
+		#StorageCapacity,
+		#SupplyDemand,
+		#OneRiver,
+		#DecliningStorage,
+		#Shortage,
+		#EraOfHope,
+		#ExtendedDrought,
+		#WaterSupply{
+			background-attachment: scroll !important;
+		}
+		
+		}
+
 @media screen and (min-width: 768px){
 	#animated-object{
 		display:block;


### PR DESCRIPTION
Ipads were not digging the background-attachment: fixed I am using to create the cool parallax effect I have on desktop, so made a special media query to detect them and give the BG images a different BG attachment so the images display properly
