### PR TITLE
fade in slower

### DIFF
--- a/public_html/js/init.js
+++ b/public_html/js/init.js
@@ -149,7 +149,7 @@ $( document ).ready( function () {
 
         window.console.trace( "Application loaded" );
         window.owdiDrought.SMController.scrollTo( 0 );
-        var fadeTimeInMs = 1500;
+        var fadeTimeInMs = 4000;
 
         $( "#overlay" ).fadeOut( fadeTimeInMs, "swing", function () {
             $( this ).remove();


### PR DESCRIPTION
flickering only occurs on dev, so trying a slower fade to see if that will cause a user to wait long enough for app to fully load.
