### PR TITLE
Scroll Lock until loaded

### DIFF
--- a/public_html/js/init.js
+++ b/public_html/js/init.js
@@ -139,6 +139,11 @@ $( document ).ready( function () {
         // so when it's populated, resolve the deferred object being returned to the caller so it
         // can act
         loadTemplateDeferred.always( deferred.resolve );
+		
+		$('body').css({'overflow':'hidden'});
+  		$(document).bind('scroll',function () { 
+       		window.scrollTo(0,0); 
+  		});
 
         return deferred;
     } )();
@@ -148,11 +153,14 @@ $( document ).ready( function () {
         // At this point, the DOM will have been built
 
         window.console.trace( "Application loaded" );
-        var fadeTimeInMs = 1500;
+        window.owdiDrought.SMController.scrollTo( 0 );
+        var fadeTimeInMs = 1000;
+		
         $( "#overlay" ).fadeOut( fadeTimeInMs, "swing", function () {
             $( this ).remove();
             $( window ).resize();
-			window.owdiDrought.SMController.scrollTo( 0 );
+			$(document).unbind('scroll'); 
+  			$('body').css({'overflow':'visible'});
         } );
 		
     } );


### PR DESCRIPTION
You are now  not allowed to scroll until the fadeout is completed as that is the sign the app is fully loaded, it eliminates the twitch we used to see.
