### PR TITLE
arrow fix for IE

### DIFF
--- a/public_html/css/main.css
+++ b/public_html/css/main.css
@@ -436,6 +436,8 @@ nav h3 {
 #scrollDownArrow{
 	position:absolute;
 	bottom:100px;
+	border:none;
+	left:50%;
 	}
 
 /*=====Blue Dragon CSS=====*/


### PR DESCRIPTION
Arrow is now in the middle of the page and no longer has odd border on it on IE 10
