### PR TITLE
zindex and new url for links

### DIFF
--- a/public_html/css/main.css
+++ b/public_html/css/main.css
@@ -162,8 +162,9 @@
 	position:absolute;
 	right:0;
 	top:25px;
-	z-index:10000;
+	z-index:9;
 	display:none;
+	font-size:.9em !important;
 	}
 
 .takeLink{

--- a/public_html/en/index.html
+++ b/public_html/en/index.html
@@ -501,7 +501,7 @@
 
 				<img id="appExplainLinkOut" src="../img/social-media/link-blue-01.svg" alt="link icon"/>
 				<div id="appExplainLink" class="takeLinkBlue" >
-					<input id="appExplainURL" type="text" value="http://go.usa.gov/#app-explanation">
+					<input id="appExplainURL" type="text" value="http://doi.gov/water/owdi.cr.drought/#app-explanation">
 				</div>
 			</div>
 			
@@ -602,7 +602,7 @@
 
 				<img id="coRiverLifeLineLinkOut" src="../img/social-media/link-blue-01.svg" alt="link icon"/>
 				<div id="coRiverLifeLineLink" class="takeLinkBlue" >
-					<input id="coRiverLifeLineURL" type="text" value="http://go.usa.gov/#coRiverLifeLine">
+					<input id="coRiverLifeLineURL" type="text" value="http://doi.gov/water/owdi.cr.drought/#coRiverLifeLine">
 				</div>
 			</div>
 			
@@ -699,7 +699,7 @@
 
 				<img id="basinDividedLinkOut" src="../img/social-media/link-blue-01.svg" alt="link icon"/>
 				<div id="basinDividedLink" class="takeLinkBlue" >
-					<input id="basinDividedURL" type="text" value="http://go.usa.gov/#basin-divided">
+					<input id="basinDividedURL" type="text" value="http://doi.gov/water/owdi.cr.drought/#basin-divided">
 				</div>
 			</div>
 		    
@@ -818,7 +818,7 @@
 
 				<img id="blueDragonLinkOut" src="../img/social-media/link-blue-01.svg" alt="link icon"/>
 				<div id="blueDragonLink" class="takeLinkBlue" >
-					<input id="blueDragonURL" type="text" value="http://go.usa.gov/#blue-dragon">
+					<input id="blueDragonURL" type="text" value="http://doi.gov/water/owdi.cr.drought/#blue-dragon">
 				</div>
 			</div>
 		
@@ -955,7 +955,7 @@
 
 				<img id="waterVariableLinkOut" src="../img/social-media/link-blue-01.svg" alt="link icon"/>
 				<div id="waterVariableLink" class="takeLinkBlue" >
-					<input id="waterVariableURL" type="text" value="http://go.usa.gov/#waterSupplyVariableContent">
+					<input id="waterVariableURL" type="text" value="http://doi.gov/water/owdi.cr.drought/#waterSupplyVariableContent">
 				</div>
 			</div>
 			
@@ -1060,7 +1060,7 @@
 
 				<img id="droughtMonitorLinkOut" src="../img/social-media/link-blue-01.svg" alt="link icon"/>
 				<div id="droughtMonitorLink" class="takeLinkBlue" >
-					<input id="droughtMonitorURL" type="text" value="http://go.usa.gov/#droughtContainer">
+					<input id="droughtMonitorURL" type="text" value="http://doi.gov/water/owdi.cr.drought/#droughtContainer">
 				</div>
 			</div>
 			
@@ -1143,7 +1143,7 @@
 
 				<img id="basinReservoirLinkOut" src="../img/social-media/link-blue-01.svg" alt="link icon"/>
 				<div id="basinReservoirLink" class="takeLinkBlue" >
-					<input id="basinReservoirURL" type="text" value="http://go.usa.gov/#basinReservoirContainer">
+					<input id="basinReservoirURL" type="text" value="http://doi.gov/water/owdi.cr.drought/#basinReservoirContainer">
 				</div>
 			</div>
 			
@@ -1246,7 +1246,7 @@
 
 				<img  id="waterUsageLinkOut" src="../img/social-media/link-blue-01.svg" alt="link icon"/>
 				<div id="waterUsageLink" class="takeLinkBlue" >
-					<input id="waterUsageURL" type="text" value="http://go.usa.gov/#waterUsageContainer">
+					<input id="waterUsageURL" type="text" value="http://doi.gov/water/owdi.cr.drought/#waterUsageContainer">
 				</div>
 			</div>
 			
@@ -1428,7 +1428,7 @@
 
 				<img id="beforeAfterLinkOut" src="../img/social-media/link-blue-01.svg" alt="link icon"/>
 				<div id="beforeAfterLink" class="takeLinkBlue" >
-					<input id="beforeAfterURL" type="text" value="http://go.usa.gov/#beforeAfterContainer">
+					<input id="beforeAfterURL" type="text" value="http://doi.gov/water/owdi.cr.drought/#beforeAfterContainer">
 				</div>
 			</div>
 		  
@@ -1543,7 +1543,7 @@
 
 				<img id="lakeMeadLinkOut" src="../img/social-media/link-blue-01.svg" alt="link icon"/>
 				<div id="lakeMeadLink" class="takeLinkBlue" >
-					<input id="lakeMeadURL" type="text" value="http://go.usa.gov/#meadStaticContainer">
+					<input id="lakeMeadURL" type="text" value="http://doi.gov/water/owdi.cr.drought/#meadStaticContainer">
 				</div>
 			</div>
 		
@@ -1878,7 +1878,7 @@
 
 				<img id="creditsLinkOut" src="../img/social-media/link-blue-01.svg" alt="link icon"/>
 				<div id="creditsLink" class="takeLinkBlue" >
-					<input id="creditsURL" type="text" value="http://go.usa.gov/#creditsContainer">
+					<input id="creditsURL" type="text" value="http://doi.gov/water/owdi.cr.drought/#creditsContainer">
 				</div>
 			</div>
 			

--- a/public_html/es/index.html
+++ b/public_html/es/index.html
@@ -501,7 +501,7 @@
 
 				<img id="appExplainLinkOut" src="../img/social-media/link-blue-01.svg" alt="link icon"/>
 				<div id="appExplainLink" class="takeLinkBlue" >
-					<input id="appExplainURL" type="text" value="http://go.usa.gov/#app-explanation">
+					<input id="appExplainURL" type="text" value="http://doi.gov/water/owdi.cr.drought/#app-explanation">
 				</div>
 			</div>
 			
@@ -602,7 +602,7 @@
 
 				<img id="coRiverLifeLineLinkOut" src="../img/social-media/link-blue-01.svg" alt="link icon"/>
 				<div id="coRiverLifeLineLink" class="takeLinkBlue" >
-					<input id="coRiverLifeLineURL" type="text" value="http://go.usa.gov/#coRiverLifeLine">
+					<input id="coRiverLifeLineURL" type="text" value="http://doi.gov/water/owdi.cr.drought/#coRiverLifeLine">
 				</div>
 			</div>
 			
@@ -699,7 +699,7 @@
 
 				<img id="basinDividedLinkOut" src="../img/social-media/link-blue-01.svg" alt="link icon"/>
 				<div id="basinDividedLink" class="takeLinkBlue" >
-					<input id="basinDividedURL" type="text" value="http://go.usa.gov/#basin-divided">
+					<input id="basinDividedURL" type="text" value="http://doi.gov/water/owdi.cr.drought/#basin-divided">
 				</div>
 			</div>
 		    
@@ -818,7 +818,7 @@
 
 				<img id="blueDragonLinkOut" src="../img/social-media/link-blue-01.svg" alt="link icon"/>
 				<div id="blueDragonLink" class="takeLinkBlue" >
-					<input id="blueDragonURL" type="text" value="http://go.usa.gov/#blue-dragon">
+					<input id="blueDragonURL" type="text" value="http://doi.gov/water/owdi.cr.drought/#blue-dragon">
 				</div>
 			</div>
 		
@@ -955,7 +955,7 @@
 
 				<img id="waterVariableLinkOut" src="../img/social-media/link-blue-01.svg" alt="link icon"/>
 				<div id="waterVariableLink" class="takeLinkBlue" >
-					<input id="waterVariableURL" type="text" value="http://go.usa.gov/#waterSupplyVariableContent">
+					<input id="waterVariableURL" type="text" value="http://doi.gov/water/owdi.cr.drought/#waterSupplyVariableContent">
 				</div>
 			</div>
 			
@@ -1059,7 +1059,7 @@
 
 				<img id="droughtMonitorLinkOut" src="../img/social-media/link-blue-01.svg" alt="link icon"/>
 				<div id="droughtMonitorLink" class="takeLinkBlue" >
-					<input id="droughtMonitorURL" type="text" value="http://go.usa.gov/#droughtContainer">
+					<input id="droughtMonitorURL" type="text" value="http://doi.gov/water/owdi.cr.drought/#droughtContainer">
 				</div>
 			</div>
 			
@@ -1142,7 +1142,7 @@
 
 				<img id="basinReservoirLinkOut" src="../img/social-media/link-blue-01.svg" alt="link icon"/>
 				<div id="basinReservoirLink" class="takeLinkBlue" >
-					<input id="basinReservoirURL" type="text" value="http://go.usa.gov/#basinReservoirContainer">
+					<input id="basinReservoirURL" type="text" value="http://doi.gov/water/owdi.cr.drought/#basinReservoirContainer">
 				</div>
 			</div>
 			
@@ -1245,7 +1245,7 @@
 
 				<img  id="waterUsageLinkOut" src="../img/social-media/link-blue-01.svg" alt="link icon"/>
 				<div id="waterUsageLink" class="takeLinkBlue" >
-					<input id="waterUsageURL" type="text" value="http://go.usa.gov/#waterUsageContainer">
+					<input id="waterUsageURL" type="text" value="http://doi.gov/water/owdi.cr.drought/#waterUsageContainer">
 				</div>
 			</div>
 			
@@ -1426,7 +1426,7 @@
 
 				<img id="beforeAfterLinkOut" src="../img/social-media/link-blue-01.svg" alt="link icon"/>
 				<div id="beforeAfterLink" class="takeLinkBlue" >
-					<input id="beforeAfterURL" type="text" value="http://go.usa.gov/#beforeAfterContainer">
+					<input id="beforeAfterURL" type="text" value="http://doi.gov/water/owdi.cr.drought/#beforeAfterContainer">
 				</div>
 			</div>
 		  
@@ -1541,7 +1541,7 @@
 
 				<img id="lakeMeadLinkOut" src="../img/social-media/link-blue-01.svg" alt="link icon"/>
 				<div id="lakeMeadLink" class="takeLinkBlue" >
-					<input id="lakeMeadURL" type="text" value="http://go.usa.gov/#meadStaticContainer">
+					<input id="lakeMeadURL" type="text" value="http://doi.gov/water/owdi.cr.drought/#meadStaticContainer">
 				</div>
 			</div>
 		
@@ -1876,7 +1876,7 @@
 
 				<img id="creditsLinkOut" src="../img/social-media/link-blue-01.svg" alt="link icon"/>
 				<div id="creditsLink" class="takeLinkBlue" >
-					<input id="creditsURL" type="text" value="http://go.usa.gov/#creditsContainer">
+					<input id="creditsURL" type="text" value="http://doi.gov/water/owdi.cr.drought/#creditsContainer">
 				</div>
 			</div>
 			

--- a/src_data/html/app-explanation.mustache
+++ b/src_data/html/app-explanation.mustache
@@ -24,7 +24,7 @@
 		{{> github}}
 		<img id="appExplainLinkOut" src="../img/social-media/link-blue-01.svg" alt="link icon"/>
 		<div id="appExplainLink" class="takeLinkBlue" >
-			<input id="appExplainURL" type="text" value="http://go.usa.gov/#app-explanation">
+			<input id="appExplainURL" type="text" value="http://doi.gov/water/owdi.cr.drought/#app-explanation">
 		</div>
 	</div>
 	

--- a/src_data/html/basin-divided.mustache
+++ b/src_data/html/basin-divided.mustache
@@ -43,7 +43,7 @@
 		{{> github}}
 		<img id="basinDividedLinkOut" src="../img/social-media/link-blue-01.svg" alt="link icon"/>
 		<div id="basinDividedLink" class="takeLinkBlue" >
-			<input id="basinDividedURL" type="text" value="http://go.usa.gov/#basin-divided">
+			<input id="basinDividedURL" type="text" value="http://doi.gov/water/owdi.cr.drought/#basin-divided">
 		</div>
 	</div>
     

--- a/src_data/html/before-after.mustache
+++ b/src_data/html/before-after.mustache
@@ -119,7 +119,7 @@
 		{{> github}}
 		<img id="beforeAfterLinkOut" src="../img/social-media/link-blue-01.svg" alt="link icon"/>
 		<div id="beforeAfterLink" class="takeLinkBlue" >
-			<input id="beforeAfterURL" type="text" value="http://go.usa.gov/#beforeAfterContainer">
+			<input id="beforeAfterURL" type="text" value="http://doi.gov/water/owdi.cr.drought/#beforeAfterContainer">
 		</div>
 	</div>
   

--- a/src_data/html/blue-dragon.mustache
+++ b/src_data/html/blue-dragon.mustache
@@ -48,7 +48,7 @@
 		{{> github}}
 		<img id="blueDragonLinkOut" src="../img/social-media/link-blue-01.svg" alt="link icon"/>
 		<div id="blueDragonLink" class="takeLinkBlue" >
-			<input id="blueDragonURL" type="text" value="http://go.usa.gov/#blue-dragon">
+			<input id="blueDragonURL" type="text" value="http://doi.gov/water/owdi.cr.drought/#blue-dragon">
 		</div>
 	</div>
 

--- a/src_data/html/co-basin-reservoir.mustache
+++ b/src_data/html/co-basin-reservoir.mustache
@@ -27,7 +27,7 @@
 		{{> github}}
 		<img id="basinReservoirLinkOut" src="../img/social-media/link-blue-01.svg" alt="link icon"/>
 		<div id="basinReservoirLink" class="takeLinkBlue" >
-			<input id="basinReservoirURL" type="text" value="http://go.usa.gov/#basinReservoirContainer">
+			<input id="basinReservoirURL" type="text" value="http://doi.gov/water/owdi.cr.drought/#basinReservoirContainer">
 		</div>
 	</div>
 	

--- a/src_data/html/co-river-lifeline.mustache
+++ b/src_data/html/co-river-lifeline.mustache
@@ -41,7 +41,7 @@
 		{{> github}}
 		<img id="coRiverLifeLineLinkOut" src="../img/social-media/link-blue-01.svg" alt="link icon"/>
 		<div id="coRiverLifeLineLink" class="takeLinkBlue" >
-			<input id="coRiverLifeLineURL" type="text" value="http://go.usa.gov/#coRiverLifeLine">
+			<input id="coRiverLifeLineURL" type="text" value="http://doi.gov/water/owdi.cr.drought/#coRiverLifeLine">
 		</div>
 	</div>
 	

--- a/src_data/html/credits.mustache
+++ b/src_data/html/credits.mustache
@@ -63,7 +63,7 @@
 		{{> github}}
 		<img id="creditsLinkOut" src="../img/social-media/link-blue-01.svg" alt="link icon"/>
 		<div id="creditsLink" class="takeLinkBlue" >
-			<input id="creditsURL" type="text" value="http://go.usa.gov/#creditsContainer">
+			<input id="creditsURL" type="text" value="http://doi.gov/water/owdi.cr.drought/#creditsContainer">
 		</div>
 	</div>
 	

--- a/src_data/html/dygraphsection.mustache
+++ b/src_data/html/dygraphsection.mustache
@@ -44,7 +44,7 @@
 		{{> github}}
 		<img id="droughtMonitorLinkOut" src="../img/social-media/link-blue-01.svg" alt="link icon"/>
 		<div id="droughtMonitorLink" class="takeLinkBlue" >
-			<input id="droughtMonitorURL" type="text" value="http://go.usa.gov/#droughtContainer">
+			<input id="droughtMonitorURL" type="text" value="http://doi.gov/water/owdi.cr.drought/#droughtContainer">
 		</div>
 	</div>
 	

--- a/src_data/html/lake-mead-static.mustache
+++ b/src_data/html/lake-mead-static.mustache
@@ -37,7 +37,7 @@
 		{{> github}}
 		<img id="lakeMeadLinkOut" src="../img/social-media/link-blue-01.svg" alt="link icon"/>
 		<div id="lakeMeadLink" class="takeLinkBlue" >
-			<input id="lakeMeadURL" type="text" value="http://go.usa.gov/#meadStaticContainer">
+			<input id="lakeMeadURL" type="text" value="http://doi.gov/water/owdi.cr.drought/#meadStaticContainer">
 		</div>
 	</div>
 

--- a/src_data/html/water-usage.mustache
+++ b/src_data/html/water-usage.mustache
@@ -45,7 +45,7 @@
 		{{> github}}
 		<img  id="waterUsageLinkOut" src="../img/social-media/link-blue-01.svg" alt="link icon"/>
 		<div id="waterUsageLink" class="takeLinkBlue" >
-			<input id="waterUsageURL" type="text" value="http://go.usa.gov/#waterUsageContainer">
+			<input id="waterUsageURL" type="text" value="http://doi.gov/water/owdi.cr.drought/#waterUsageContainer">
 		</div>
 	</div>
 	

--- a/src_data/html/waterSupplyVariableContent.mustache
+++ b/src_data/html/waterSupplyVariableContent.mustache
@@ -73,7 +73,7 @@
 		{{> github}}
 		<img id="waterVariableLinkOut" src="../img/social-media/link-blue-01.svg" alt="link icon"/>
 		<div id="waterVariableLink" class="takeLinkBlue" >
-			<input id="waterVariableURL" type="text" value="http://go.usa.gov/#waterSupplyVariableContent">
+			<input id="waterVariableURL" type="text" value="http://doi.gov/water/owdi.cr.drought/#waterSupplyVariableContent">
 		</div>
 	</div>
 	


### PR DESCRIPTION
Changed the link icons urls to match the twitter url for the website, can be easily changed if url is different in future.

The link popup had too high of a z-index and  floated over nav, now will float under the nav if left open and scrolled up as intended.
